### PR TITLE
better cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -9,13 +9,6 @@ file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
-    libs/cocos-headers/cocos2dx
-    libs/cocos-headers/cocos2dx/include
-    libs/cocos-headers/cocos2dx/kazmath/include
-    libs/cocos-headers/cocos2dx/platform/third_party/win32/OGLES
-    libs/cocos-headers/cocos2dx/platform/win32
-    libs/cocos-headers/extensions
-    libs/MinHook
     libs/gd.h/include
     libs/gd.h
     libs/imgui-hook
@@ -24,9 +17,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 add_subdirectory(libs/minhook)
 add_subdirectory(libs/imgui-hook)
+add_subdirectory(libs/cocos-headers)
 
-target_link_libraries(${PROJECT_NAME} minhook)
-target_link_libraries(${PROJECT_NAME} imgui-hook)
-target_link_libraries(${PROJECT_NAME} opengl32)
-target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/libs/cocos-headers/cocos2dx/libcocos2d.lib)
-target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/libs/cocos-headers/extensions/libExtensions.lib)
+target_link_libraries(${PROJECT_NAME} minhook imgui-hook opengl32 cocos2d)


### PR DESCRIPTION
Поменял версию смейка, потому что с++20 поддерживается только в 3.12 или выше. 
Minhook и cocos-headers уже имеют target_include_directories.
target_link_libraries сместил в одну строку.

Я GD Ephir